### PR TITLE
Fix installing LINC-Switch after modifying rebar configuration

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -271,8 +271,9 @@ function linc_switch {
         git checkout ${LINC_SWITCH_REV}
     fi
 
-    sudo make rel
     REL_DIR=$BUILD_DIR/$LINC_SWITCH_DIR/rel
+    cp $REL_DIR/files/sys.config.orig $REL_DIR/files/sys.config
+    sudo make rel
 
     LINC_START_COMMAND="#!/bin/sh\ncd $REL_DIR && ./linc/bin/linc \$@"
     install_command "$LINC_START_COMMAND" $REL_DIR/linc.start linc


### PR DESCRIPTION
Sys.config file has been removed from the version control system but LINC
won't start without it. In face of that is need to be created manually.
(Motivated by FlowForwarding/LINC-Switch#242).
