### PR TITLE
Update URL for downloading kerl

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -775,7 +775,7 @@ function install_erlang {
 
     if [ ! `which kerl` ]; then
         KERL_DESTINATION="/usr/local/bin/kerl"
-        curl -o $KERL_DESTINATION -O https://raw.github.com/spawngrid/kerl/master/kerl
+        curl --fail -o $KERL_DESTINATION -O https://raw.github.com/spawngrid/kerl/master/kerl
         chmod a+x $KERL_DESTINATION
     fi
 

--- a/util/install.sh
+++ b/util/install.sh
@@ -775,7 +775,7 @@ function install_erlang {
 
     if [ ! `which kerl` ]; then
         KERL_DESTINATION="/usr/local/bin/kerl"
-        curl --fail -o $KERL_DESTINATION -O https://raw.github.com/spawngrid/kerl/master/kerl
+        curl --fail -o $KERL_DESTINATION -O https://raw.githubusercontent.com/spawngrid/kerl/master/kerl
         chmod a+x $KERL_DESTINATION
     fi
 


### PR DESCRIPTION
The URL has changed from `raw.github.com` to `raw.githubusercontent.com`.

Also pass `--fail` to curl, to get a non-zero exit code when the download fails.
