### PR TITLE
Make util/install.sh idempotent

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -574,6 +574,7 @@ function nox13 {
 
     # Fetch NOX destiny
     cd $BUILD_DIR/
+    rm -rf nox13oflib
     git clone https://github.com/CPqD/nox13oflib.git
     cd nox13oflib
 
@@ -595,6 +596,7 @@ function nox13 {
 function pox {
     echo "Installing POX into $BUILD_DIR/pox..."
     cd $BUILD_DIR
+    rm -rf pox
     git clone https://github.com/noxrepo/pox.git
 }
 
@@ -607,6 +609,7 @@ function oftest {
 
     # Install oftest:
     cd $BUILD_DIR/
+    rm -rf oftest
     git clone git://github.com/floodlight/oftest
 }
 
@@ -620,6 +623,7 @@ function cbench {
         $install libsnmp-dev libpcap-dev libconfig-dev
     fi
     cd $BUILD_DIR/
+    rm -rf oflops
     git clone git://gitosis.stanford.edu/oflops.git
     cd oflops
     sh boot.sh || true # possible error in autoreconf, so run twice

--- a/util/install.sh
+++ b/util/install.sh
@@ -221,6 +221,8 @@ function of13 {
     NBEESRC="nbeesrc-jan-10-2013"
     NBEEURL=${NBEEURL:-http://www.nbee.org/download/}
     wget -nc ${NBEEURL}${NBEESRC}.zip
+    # Remove existing directory, if any
+    rm -rf ${NBEESRC}
     unzip ${NBEESRC}.zip
     cd ${NBEESRC}/src
     cmake .


### PR DESCRIPTION
Remove existing directories before unpacking/cloning new ones. This means that `util/install.sh` can be run several times without manual cleanup in between, which can be useful while debugging.
